### PR TITLE
:alembic: Attempts to reduce exercism/swift-test-runner size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,63 @@
-FROM swift:6.1.2 AS builder
-# WORKDIR /opt/testrunner
+FROM swift:6.1.2 AS test-runner-builder
 
+WORKDIR /build
 COPY src/TestRunner ./
+RUN swift --version && swift build --configuration release
 
-# Print Installed Swift Version
-RUN swift --version
-#RUN swift package clean
-RUN swift build --configuration release
 
-FROM swift:6.1.2
-RUN apt-get update && apt-get install -y jq
-WORKDIR /opt/test-runner/
-COPY bin/ bin/
+FROM swift:6.1.2 AS dependencies-builder
 
+WORKDIR /build
 COPY Package.swift ./Package.swift
-
 RUN swift build
 
-COPY --from=builder /.build/release/TestRunner bin/
 
-ENV NAME RUNALL
+FROM debian:12
+
+WORKDIR /opt
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+   # Test runner
+   jq \
+   # Swift requirements from https://www.swift.org/install/linux/tarball/
+   binutils-gold \
+   gcc \
+   git \
+   libcurl4-openssl-dev \
+   libedit-dev \
+   libicu-dev \
+   libncurses-dev \
+   libpython3-dev \
+   libsqlite3-dev \
+   libxml2-dev \
+   pkg-config \
+   tzdata \
+   uuid-dev \
+   # Packages to downlaod Swift
+   wget ca-certificates \
+   # Packages to verify (GPG)
+   gpg dirmngr gpg-agent \
+ && rm -rf /var/lib/apt/lists/* \
+ # https://download.swift.org/swift-6.1.2-release/debian12/swift-6.1.2-RELEASE/swift-6.1.2-RELEASE-debian12.tar.gz
+ && wget https://download.swift.org/swift-6.1.2-release/debian12/swift-6.1.2-RELEASE/swift-6.1.2-RELEASE-debian12.tar.gz \
+ && wget https://download.swift.org/swift-6.1.2-release/debian12/swift-6.1.2-RELEASE/swift-6.1.2-RELEASE-debian12.tar.gz.sig \
+ # "Swift 6.x Release Signing Key" from https://www.swift.org/keys/active/
+ && gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys '52BB 7E3D E28A 71BE 22EC 05FF EF80 A866 B47A 981F' \
+ && gpg --verify swift-6.1.2-RELEASE-debian12.tar.gz.sig \
+ # Unpack the tarball
+ && tar xf swift-6.1.2-RELEASE-debian12.tar.gz \
+ && mv swift-6.1.2-RELEASE-debian12/usr/ swift/ \
+ # Cleanup image (apt packages, downloaded files)
+ && apt-get purge -y wget ca-certificates gpg dirmngr gpg-agent \
+ && apt-get autoremove -y --purge \
+ && rm swift-6.1.2-RELEASE-debian12.tar.gz swift-6.1.2-RELEASE-debian12.tar.gz.sig
+
+ENV PATH="$PATH:/opt/swift/bin"
+WORKDIR /opt/test-runner/
+COPY bin/ bin/
+COPY --from=test-runner-builder /build/.build/release/TestRunner bin/
+COPY --from=dependencies-builder /build /opt/test-runner
+
+ENV NAME=RUNALL
 
 ENTRYPOINT ["./bin/run.sh"]


### PR DESCRIPTION
This image is the biggest in the https://hub.docker.com/u/exercism organisation.

Currently it is 1_110_637_301bytes compressed and 3.48GB uncompressed.

It uses swift:6.1.2 image as base which already is 3.37G uncompressed.

## Attempt 1

Use `swift:6.1.2-slim` as base.

Fails because the test runner tries to run `swift test` and `swift` is not part of the image.

## Attempt 2

Install swift ourselves in debian:12 following https://www.swift.org/install/linux/tarball/

It gives an image of about the same size 3.53GB, and currently fails.

Using https://github.com/wagoodman/dive the biggest files are:
```txt
drwxr-xr-x         0:0     2.9 GB  ├── opt
drwxr-xr-x         0:0     2.9 GB  │   ├── swift
drwxr-xr-x         0:0     1.6 GB  │   │   ├── lib
drwxr-xr-x         0:0     891 MB  │   │   │   ├── swift
drwxr-xr-x         0:0     471 MB  │   │   │   │   ├── embedded
drwxr-xr-x         0:0     439 MB  │   │   │   │   │   ├── Swift.swiftmodule
-rw-r--r--         0:0      18 MB  │   │   │   │   │   │   ├── avr-none-none-elf.swiftmodule # Maybe we can save space removing targets?
-rw-r--r--         0:0      18 MB  │   │   │   │   │   │   ├── armv4t-none-none-eabi.swiftmodule
-rw-r--r--         0:0      18 MB  │   │   │   │   │   │   ├── armv6-apple-none-macho.swiftmodule
-rw-r--r--         0:0      18 MB  │   │   │   │   │   │   ├── armv6m-apple-none-macho.swiftmodule
-rw-r--r--         0:0     205 MB  │   │   │   ├── liblldb.so.17.0.0 # Maybe we could have a swift build without lldb (debugger)?
-rw-r--r--         0:0     198 MB  │   │   │   ├── libsourcekitdInProc.so
drwxr-xr-x         0:0     172 MB  │   │   │   ├─⊕ swift_static
drwxr-xr-x         0:0      81 MB  │   │   │   ├─⊕ clang
-rw-r--r--         0:0      80 MB  │   │   │   ├── libLTO.so.17.0
drwxr-xr-x         0:0     1.3 GB  │   │   ├── bin
-rwxr-xr-x         0:0     196 MB  │   │   │   ├── swift-frontend
-rwxr-xr-x         0:0     191 MB  │   │   │   ├── sourcekit-lsp
-rwxr-xr-x         0:0     165 MB  │   │   │   ├── clang-17
-rwxr-xr-x         0:0     158 MB  │   │   │   ├── swift-package
-rwxr-xr-x         0:0     132 MB  │   │   │   ├── lldb-server
drwxr-xr-x         0:0      39 MB  │   ├── test-runner # This is our binary
drwxr-xr-x         0:0     573 MB  ├── usr
drwxr-xr-x         0:0     373 MB  │   ├── lib
drwxr-xr-x         0:0     227 MB  │   │   ├─⊕ x86_64-linux-gnu
drwxr-xr-x         0:0      82 MB  │   │   ├─⊕ gcc
drwxr-xr-x         0:0     100 MB  │   ├── share
drwxr-xr-x         0:0      57 MB  │   │   ├─⊕ locale
drwxr-xr-x         0:0      18 MB  │   │   ├─⊕ doc
drwxr-xr-x         0:0     100 MB  │   ├─⊕ share
drwxr-xr-x         0:0      77 MB  │   ├─⊕ bin
```

## Conclusion

I could not find a way to substantially reduce this image size