### PR TITLE
Bake RUN_IN_DOCKER into Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,6 @@ COPY --from=builder /TestRunner/.build/release/TestRunner bin/
 COPY --from=builder /opt/test-runner/.build .build
 COPY --from=builder /opt/test-runner/Package.resolved Package.resolved
 
+ENV RUN_IN_DOCKER=TRUE
+
 ENTRYPOINT ["./bin/run.sh"]

--- a/bin/benchmark-in-docker.sh
+++ b/bin/benchmark-in-docker.sh
@@ -36,4 +36,4 @@ CURRENT_PATH=${PWD}
 
 hyperfine \
     --parameter-list slug $(find tests -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | paste -sd ",") \
-    "bin/run-in-docker.sh {slug} $CURRENT_PATH/tests/{slug} $CURRENT_PATH/tests/{slug}"
+    "SKIP_DOCKER_BUILD=true bin/run-in-docker.sh {slug} $CURRENT_PATH/tests/{slug} $CURRENT_PATH/tests/{slug}"

--- a/bin/benchmark-in-docker.sh
+++ b/bin/benchmark-in-docker.sh
@@ -36,4 +36,4 @@ CURRENT_PATH=${PWD}
 
 hyperfine \
     --parameter-list slug $(find tests -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | paste -sd ",") \
-    "SKIP_DOCKER_BUILD=true bin/run-in-docker.sh {slug} $CURRENT_PATH/tests/{slug} $CURRENT_PATH/tests/{slug}"
+    "bin/run-in-docker.sh {slug} $CURRENT_PATH/tests/{slug} $CURRENT_PATH/tests/{slug}"

--- a/bin/run-in-docker.sh
+++ b/bin/run-in-docker.sh
@@ -43,5 +43,4 @@ docker run \
     --mount type=bind,src="${INPUT_DIR}",dst=/solution \
     --mount type=bind,src="${OUTPUT_DIR}",dst=/output \
     --mount type=volume,dst=/tmp \
-    -e RUN_IN_DOCKER=TRUE \
     exercism/swift-test-runner $SLUG /solution/ /output/

--- a/bin/run-tests-in-docker.sh
+++ b/bin/run-tests-in-docker.sh
@@ -28,7 +28,6 @@ for test_dir in tests/*; do
         --mount type=volume,dst=/tmp \
         --workdir "${work_dir}" \
         --entrypoint ${work_dir}/bin/run-test.sh \
-        -e RUN_IN_DOCKER=TRUE \
         exercism/swift-test-runner \
         "${dst_test_dir}"
 

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -25,8 +25,12 @@ SLUG="$1"
 INPUT_DIR="${2%/}"
 OUTPUT_DIR="${3%/}"
 
-WORKING_DIR="${PWD}"
-cp -r "${INPUT_DIR}/." "${WORKING_DIR}"
+if [[ "${RUN_IN_DOCKER}" == "TRUE" ]]; then  
+    WORKING_DIR="${PWD}"
+    cp -r "${INPUT_DIR}/." "${WORKING_DIR}"
+else
+    WORKING_DIR=${INPUT_DIR}
+fi
 
 junit_file="${WORKING_DIR}/results-swift-testing.xml"
 spec_file="${WORKING_DIR}/$(jq -r '.files.test[0]' ${WORKING_DIR}/.meta/config.json)"


### PR DESCRIPTION
Post-review changes after #63 and #64.

Currently, the test-runner supports two execution environments: a Docker container and the local environment.
The main difference between them lies in the run.sh script, specifically in which folder is used as the working directory.
- For the Docker environment, the working directory is inside the container.
- For the local environment, the working directory is the exercise folder itself.
As run.sh is used for both environements, RUN_IN_DOCKER is used to manage working directory. Building an exercise inside the Docker container instead of on a mounted volume showed exercise build time improvement.

This PR fixes how the RUN_IN_DOCKER environment variable is injected. Previously, it was incorrectly passed from external scripts. Now, it is embedded directly into the Docker image and should not be supplied from outside.