### PR TITLE
Switch test runner to use swift-docker-base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
+ARG REPO=exercism/swift-docker-base
+ARG IMAGE=latest
+
 # Stage 1: Precompile TestRunner
-FROM swift:6.1.2 AS builder
+FROM ${REPO}:${IMAGE} AS builder
 RUN swift --version
 
 # Build TestRunner executable
@@ -8,7 +11,7 @@ COPY src/TestRunner .
 RUN swift build --configuration release
 
 # Stage 2: Prepare docker container image
-FROM swift:6.1.2
+FROM ${REPO}:${IMAGE} AS base
 RUN apt-get update && apt-get install -y jq
 
 WORKDIR /opt/test-runner

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 2.0.5
+
+- Base image for docker is now exercism/swift-docker-base.
+
 # 2.0.4
 
 - The WarmUp package has been renamed to TestEnvironment and is now used directly to build exercise solutions.

--- a/tests/multiple-tests-multiple-fails/expected_results.json
+++ b/tests/multiple-tests-multiple-fails/expected_results.json
@@ -2,13 +2,13 @@
   "status" : "fail",
   "tests" : [
     {
-      "message" : "Expectation failed: (sum(2, 3) → -1) == 5: 2+3 should equal 5",
+      "message" : "Expectation failed: (sum(2, 3) → -1) == 5 (error): 2+3 should equal 5",
       "name" : "test Add",
       "status" : "fail",
       "test_code" : "#expect(sum(2, 3) == 5, \"2+3 should equal 5\")"
     },
     {
-      "message" : "Expectation failed: (sub(2, 3) → 5) == -1",
+      "message" : "Expectation failed: (sub(2, 3) → 5) == -1 (error)",
       "name" : "test Sub",
       "status" : "fail",
       "test_code" : "#expect(sub(2, 3) == -1)"

--- a/tests/multiple-tests-single-fail/expected_results.json
+++ b/tests/multiple-tests-single-fail/expected_results.json
@@ -2,7 +2,7 @@
   "status" : "fail",
   "tests" : [
     {
-      "message" : "Expectation failed: (sum(2, 3) → 0) == 5: 2+3 should equal 5",
+      "message" : "Expectation failed: (sum(2, 3) → 0) == 5 (error): 2+3 should equal 5",
       "name" : "test Add",
       "status" : "fail",
       "test_code" : "#expect(sum(2, 3) == 5, \"2+3 should equal 5\")"
@@ -18,7 +18,7 @@
       "test_code" : "#expect(mul(2, 3) == 6)"
     },
     {
-      "message" : "Expectation failed: (sum(12, 13) → 0) == 25: 12+13 should equal 25",
+      "message" : "Expectation failed: (sum(12, 13) → 0) == 25 (error): 12+13 should equal 25",
       "name" : "test Add 2",
       "status" : "fail",
       "test_code" : "#expect(sum(12, 13) == 25, \"12+13 should equal 25\")"

--- a/tests/single-test-that-fails/expected_results.json
+++ b/tests/single-test-that-fails/expected_results.json
@@ -2,7 +2,7 @@
   "status" : "fail",
   "tests" : [
     {
-      "message" : "Expectation failed: (sum(2, 3) → -1) == 5: 2+3 should equal 5",
+      "message" : "Expectation failed: (sum(2, 3) → -1) == 5 (error): 2+3 should equal 5",
       "name" : "test Add",
       "status" : "fail",
       "test_code" : "#expect(sum(2, 3) == 5, \"2+3 should equal 5\")"


### PR DESCRIPTION
Switching to created docker swift base image, that should reduce swift-test-runner docker image.

More info here: https://forum.exercism.org/t/create-a-repo-swift-docker-base-for-swift-track/19449